### PR TITLE
Drop provinding_args as it was depreacted on django 4.x

### DIFF
--- a/tenant_schemas/signals.py
+++ b/tenant_schemas/signals.py
@@ -1,6 +1,6 @@
 from django.dispatch import Signal
 
-post_schema_sync = Signal(providing_args=['tenant'])
+post_schema_sync = Signal()
 post_schema_sync.__doc__ = """
 Sent after a tenant has been saved, its schema created and synced
 """


### PR DESCRIPTION
Reason: https://github.com/django/django/pull/12513